### PR TITLE
Fix e-antic link

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 The flatsurf software suite is a collection of mathematical software libraries to study [translation surfaces](https://en.wikipedia.org/wiki/Translation_surface) and related objects. It consists of:
 
-* [e-antic](https://flatsurf.github.io/e-antic/libeantic/) for real embedded number fields,
+* [e-antic](https://flatsurf.github.io/e-antic/) for real embedded number fields,
 * [exact-real](https://github.com/flatsurf/exact-real/) for exact real numbers,
 * [intervalxt](https://github.com/flatsurf/intervalxt/) for [interval exchange transformations](https://en.wikipedia.org/wiki/Interval_exchange_transformation),
 * [flatsurf](https://github.com/flatsurf/flatsurf/), [surface-dynamics](https://flatsurf.github.io/surface-dynamics/), [sage-flatsurf](https://flatsurf.github.io/sage-flatsurf) for translation surfaces,
@@ -16,8 +16,8 @@ Explore some features by taking the [➡️ tour of flatsurf](https://flatsurf.g
 * [curver](https://github.com/MarkCBell/curver) calculations in the curve complex in Python
 * [edwards_algorithm](https://github.com/slade96/edwards_algorithm) computes generators of the Veech group of a translation surface in SageMath when the group is a lattice
 * [flipper](https://flipper.readthedocs.io/en/latest/) computes the action of mapping classes on laminations on punctured surfaces in Python
-* [MapClass](https://www.gap-system.org/Packages/mapclass.html) calculates the mapping class group orbits for a given finite group
-* [Origami](https://github.com/AG-Weitze-Schmithusen/Origami) provides calculations for origamis in GAP
+* [MapClass](https://gap-packages.github.io/MapClass) calculates the mapping class group orbits for a given finite group
+* [Origami](https://ag-weitze-schmithusen.github.io/Origami) provides calculations for origamis in GAP
 * [SnOrbitProject](https://gitlab.eecs.umich.edu/translationsurfaces/snorbitproject) decides whether a genus two translation surface has a convex pattern
 * [Veering](https://github.com/henryseg/Veering) for working with transverse taut and veering ideal triangulations
 
@@ -35,7 +35,7 @@ You can also reach out to us by [email](mailto:contact@flatsurf.org) <!--
 currently being forwarded to Julian --> or join us on
 [Zulip](https://sagemath.zulipchat.com) in the
 [#flatsurf](https://sagemath.zulipchat.com/#narrow/stream/271193-flatsurf)
-stream.
+channel.
 
 ### Installation
 


### PR DESCRIPTION
Also update some GAP package links.

Also reword Zulip stream to channel following the official change, see:

-   https://github.com/zulip/zulip/issues/28468
-   https://chat.zulip.org/#narrow/stream/101-design/topic/.22Stream.22.20vs.20.22Channel.22/near/1657433